### PR TITLE
[Doppins] Upgrade dependency grunt-babel to 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "babel": "^5.8.34",
     "babel-plugin-uglify": "^1.0.2",
     "chai": "^3.3.0",
-    "grunt-babel": "5.0.3",
+    "grunt-babel": "6.0.0",
     "grunt": ">=0.4.5 <1.0.0",
     "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "^0.6.0",


### PR DESCRIPTION
Hi!

A new version was just released of `grunt-babel`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded grunt-babel from `5.0.3` to `6.0.0`

#### Changelog:

#### Version 6.0.0
Upgrade to Babel 6.0.0: http://babeljs.io/blog/2015/10/29/6.0.0/

