### PR TITLE
[Doppins] Upgrade dependency grunt to >=1.0.1 <2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "babel-plugin-uglify": "^1.0.2",
     "chai": "^3.3.0",
     "grunt-babel": "5.0.3",
-    "grunt": ">=0.4.5 <1.0.0",
+    "grunt": ">=1.0.1 <2.0.0",
     "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-copy": "^0.8.2",


### PR DESCRIPTION
Hi!

A new version was just released of `grunt`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded grunt from `>=0.4.5 <1.0.0` to `>=1.0.1 <2.0.0`

